### PR TITLE
fix(blockquotes): first line break without alerts not working

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,34 +41,29 @@ const processNode =
       // So we just need to addtionally check if the following one is a block.
       // The legacy title variant is not affected since it checks an inline and does not care about the newline.
 
-      // If this is not a gfm alert then we would manipulate the original children and the next processor would not be able to handle the children correctly.
-      const paragraphChildrenCopy = [...paragraph.children]
-
-      // No addtional inlines can exist in this paragraph for the title...
-      if (paragraphChildrenCopy.length > 1) {
-        // Unless it is an inline break, which can be transformed to from 2 spaces with a newline.
-        if (paragraphChildrenCopy.at(1)?.type == 'break') {
-          // When it is, we actually have already found the line break required by GitHub.
-          // So we just strip the additional `<br>` element.
-          // The title element will be removed later.
-          paragraphChildrenCopy.splice(1, 1)
-        } else {
-          return
-        }
-      }
-
       // Considering the reason why the paragraph ends here, the following one should be a children of the blockquote, which means it is always a block.
       // So no more check is required.
       title = text.value
       admonitionType = config.types[title]
 
-      if (admonitionType) {
-        // Remove the text as the title
-        paragraph.children.shift()
-        paragraph.children.shift()
-      } else {
+      if (!admonitionType) {
         return
       }
+
+      // No addtional inlines can exist in this paragraph for the title...
+      if (paragraph.children.length > 1) {
+        // Unless it is an inline break, which can be transformed to from 2 spaces with a newline.
+        if (paragraph.children.at(1)?.type == 'break') {
+          // When it is, we actually have already found the line break required by GitHub.
+          // So we just strip the additional `<br>` element.
+          // The title element will be removed later.
+          paragraph.children.splice(1, 1)
+        } else {
+          return
+        }
+      }
+      // strip the title
+      paragraph.children.shift()
     } else {
       const textBody = text.value.substring(titleEnd + 1)
       title = text.value.substring(0, titleEnd)

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,14 +41,17 @@ const processNode =
       // So we just need to addtionally check if the following one is a block.
       // The legacy title variant is not affected since it checks an inline and does not care about the newline.
 
+      // If this is not a gfm alert then we would manipulate the original children and the next processor would not be able to handle the children correctly.
+      const paragraphChildrenCopy = [...paragraph.children]
+
       // No addtional inlines can exist in this paragraph for the title...
-      if (paragraph.children.length > 1) {
+      if (paragraphChildrenCopy.length > 1) {
         // Unless it is an inline break, which can be transformed to from 2 spaces with a newline.
-        if (paragraph.children.at(1)?.type == 'break') {
+        if (paragraphChildrenCopy.at(1)?.type == 'break') {
           // When it is, we actually have already found the line break required by GitHub.
           // So we just strip the additional `<br>` element.
           // The title element will be removed later.
-          paragraph.children.splice(1, 1)
+          paragraphChildrenCopy.splice(1, 1)
         } else {
           return
         }
@@ -61,6 +64,7 @@ const processNode =
 
       if (admonitionType) {
         // Remove the text as the title
+        paragraph.children.shift()
         paragraph.children.shift()
       } else {
         return

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -120,3 +120,25 @@ exports[`GitHub beta blockquote-based admonitions with titles like [!NOTE] > sho
 </ul>
 </div>"
 `;
+
+exports[`verify default behavior with plugin enabled > should transform a plain blockquote with line breaks ("  " - note the two spaces) 1`] = `
+"<blockquote>
+<p>Each time you increase the amount of code, your software grows exponentially more complicated.<br>
+-- DHH, Getting Real</p>
+</blockquote>"
+`;
+
+exports[`verify default behavior with plugin enabled > should transform a plain blockquote with line breaks (\\) 1`] = `
+"<blockquote>
+<p>Each time you increase the amount of code, your software grows exponentially more complicated.<br>
+-- DHH, Getting Real</p>
+</blockquote>"
+`;
+
+exports[`verify default behavior with plugin enabled > should transform a plain blockquote with line breaks (\\) 2x 1`] = `
+"<blockquote>
+<p>Each time you increase the amount of code, your software grows exponentially more complicated.<br>
+-- DHH, Getting Real<br>
+-- DHH, Getting Real</p>
+</blockquote>"
+`;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -224,3 +224,42 @@ describe('GitHub beta blockquote-based admonitions with titles like [!NOTE]', fu
     }
   })
 })
+
+describe('verify default behavior with plugin enabled', function () {
+  defineCase('should transform a plain blockquote with line breaks (\\)', {
+    input: `\
+> Each time you increase the amount of code, your software grows exponentially more complicated.\\
+> -- DHH, Getting Real
+`,
+    assertions(html) {
+      const elem = selectAll('blockquote > p > br', parseDocument(html))
+      expect(elem).to.lengthOf(1)
+    }
+  })
+
+  defineCase(
+    'should transform a plain blockquote with line breaks ("  " - note the two spaces)',
+    {
+      input: `\
+> Each time you increase the amount of code, your software grows exponentially more complicated.  
+> -- DHH, Getting Real
+`,
+      assertions(html) {
+        const elem = selectAll('blockquote > p > br', parseDocument(html))
+        expect(elem).to.lengthOf(1)
+      }
+    }
+  )
+
+  defineCase('should transform a plain blockquote with line breaks (\\) 2x', {
+    input: `\
+> Each time you increase the amount of code, your software grows exponentially more complicated.\\
+> -- DHH, Getting Real\\
+> -- DHH, Getting Real
+`,
+    assertions(html) {
+      const elem = selectAll('blockquote > p > br', parseDocument(html))
+      expect(elem).to.lengthOf(2)
+    }
+  })
+})


### PR DESCRIPTION
Due to the manipulation of the paragraph children, the first line break was not processed correctly if the blockqute is not a gfm alert.