### PR TITLE
fix(styles): color of nested alerts

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -27,31 +27,31 @@ p.gfm-alert-title {
 }
 
 .gfm-alert-type-note {
-  p.gfm-alert-title {
+  > p.gfm-alert-title {
     color: var(--gfm-alert-note);
   }
   border-color: var(--gfm-alert-note);
 }
 .gfm-alert-type-tip {
-  p.gfm-alert-title {
+  > p.gfm-alert-title {
     color: var(--gfm-alert-tip);
   }
   border-color: var(--gfm-alert-tip);
 }
 .gfm-alert-type-important {
-  p.gfm-alert-title {
+  > p.gfm-alert-title {
     color: var(--gfm-alert-important);
   }
   border-color: var(--gfm-alert-important);
 }
 .gfm-alert-type-warning {
-  p.gfm-alert-title {
+  > p.gfm-alert-title {
     color: var(--gfm-alert-warning);
   }
   border-color: var(--gfm-alert-warning);
 }
 .gfm-alert-type-caution {
-  p.gfm-alert-title {
+  > p.gfm-alert-title {
     color: var(--gfm-alert-caution);
   }
   border-color: var(--gfm-alert-caution);


### PR DESCRIPTION
> It looks like nested alerts dont have the correct color in Inkdrop.
> 
> ## How to reproduce
> 
> ```markdown
> > [!CAUTION]
> > Negative potential consequences of an action.
> > > [!NOTE]  
> > > Test nested
> ```
> The outer warning message is red. In the inner message, the text and the icon are also red instead of blue.
> ![grafik](https://github.com/inkdropapp/gfm-alerts/assets/100614278/a4481e52-0a42-4526-8e6e-da3bfcd606df)
> 
> ## Expected behavior
> 
> I would expect that the outer warning is displayed in red and the inner warning in blue.
> ![grafik](https://github.com/inkdropapp/gfm-alerts/assets/100614278/6f341ef2-c0ef-45d7-ac74-4e88d45e5119)


---

I have made a change that *should* fix this behavior. I have tried to test this within Inkdrop as i am not sure how this could be tested within this repository.

I needed to adjust the style a bit so that i can apply it via a user stylesheet (in inkdrop).  So i am not 100% sure if this fixes the problem (although it should be fixed).

Maybe you can test it better.
